### PR TITLE
Using RFC 3986 encoding for signature generation

### DIFF
--- a/lib/amazon.js
+++ b/lib/amazon.js
@@ -1,7 +1,6 @@
 var request = require('request');
 var crypto = require('crypto');
 var URL = require('url');
-var qs = require('querystring');
 var xml2js = require('xml2js');
 
 var error = require('./error');
@@ -130,9 +129,7 @@ function attachSignature(url, secret, params) {
   var sortedParams = Object.keys(params).sort(function(a, b) {
     return a == b ? 0 : a < b ? -1 : 1;
   }).map(function(key) {
-    var param = {};
-    param[key] = params[key];
-    return qs.stringify(param).replace("%7E", "~");
+    return RFC3986Encode(key) + '=' + RFC3986Encode(params[key]);
   }).join('&');
 
   var parsedUrl = URL.parse(url);
@@ -160,6 +157,12 @@ function getFormattedTimestamp(date) {
   var second = padNum(date.getUTCSeconds());
 
   return year + '-' + month + '-' + day + 'T' + hour + ':' + minute + ':' + second + 'z';
+}
+
+function RFC3986Encode(str) {
+  return encodeURIComponent(str).replace(/[!'()*]/g, function(c) {
+    return '%' + c.charCodeAt(0).toString(16);
+  });
 }
 
 function padNum(num, size, str) {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "email": "scottspork@gmail.com"
   },
   "description": "API wrapper for Amazon Payments",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "main": "amazonPayments.js",
   "repository": {
     "type": "git",
@@ -24,8 +24,7 @@
   ],
   "dependencies": {
     "request": "2.34.0",
-    "xml2js": "0.4.4",
-    "qs": "0.6.6"
+    "xml2js": "0.4.4"
   },
   "devDependencies": {
     "mocha": "1.17.1"

--- a/test/param.js
+++ b/test/param.js
@@ -49,5 +49,23 @@ describe('param composition', function() {
       assert.equal(sigParams.Signature, 'r/Iae1ZvKIT+v3RqxAH0Fv5bK4KxOCf1jp0tJIBx5Mk=');
       assert.equal(Object.keys(sigParams).length, 5);
     });
+
+    it('should correctly escape special characters', function() {
+      var url = 'https://mws.amazonservices.com/OffAmazonPayments_Sandbox';
+      var secret = 'thisIsMySuperSecretKey';
+      var params = {
+        test1: 'value * with non-alpha numeric special characters (like parenthesis, {braces}, [brackets], or others: ~`!@#$%^&*_+<>?:)',
+        test2: 'ßπéçîå£ ü†ƒ çhå®åç†é®ß',
+        test3: 'These are fine: -_.~'
+      };
+      var sigParams = amazon.attachSignature(url, secret, params);
+      assert.equal(sigParams.test1, params.test1);
+      assert.equal(sigParams.test2, params.test2);
+      assert.equal(sigParams.test3, params.test3);
+      assert.equal(sigParams.SignatureMethod, 'HmacSHA256');
+      assert.equal(sigParams.SignatureVersion, 2);
+      assert.equal(sigParams.Signature, '+LC2vMBuR51S94bAVK9DctDJC0XQCZ4vmQ6CKBYyTf4=');
+      assert.equal(Object.keys(sigParams).length, 6);
+    });
   });
 });


### PR DESCRIPTION
This fixes the issue where certain special characters weren't getting encoded to their correct percent code. Also removes querystring module dependency.
